### PR TITLE
Check OPENAI_API_KEY before initialization

### DIFF
--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -1,9 +1,15 @@
 import OpenAI from "openai";
 
 // Using gpt-4o as requested for GPT-4.1 functionality with web search capabilities
-const openai = new OpenAI({ 
-  apiKey: process.env.OPENAI_API_KEY 
-});
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  throw new Error(
+    "Missing OpenAI API key. Please set the OPENAI_API_KEY environment variable."
+  );
+}
+
+const openai = new OpenAI({ apiKey });
 
 export interface PropertyData {
   propertyDescription: string;


### PR DESCRIPTION
## Summary
- ensure OpenAI is only constructed when `OPENAI_API_KEY` is set
- provide a clear error message if the key is missing

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685479c3ab1c83248077cb9062079f48