### PR TITLE
Add valuation detail page with navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
 import History from "@/pages/history";
+import ValuationDetail from "@/pages/valuation-detail";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -12,6 +13,7 @@ function Router() {
     <Switch>
       <Route path="/" component={Home} />
       <Route path="/history" component={History} />
+      <Route path="/valuation/:id" component={ValuationDetail} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocation } from "wouter";
 import { ValuationHistory } from "@/components/valuation-history";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -9,6 +10,7 @@ import { History, Search, MapPin, TrendingUp } from "lucide-react";
 export default function HistoryPage() {
   const [searchLocation, setSearchLocation] = useState("");
   const [activeLocation, setActiveLocation] = useState<string | undefined>();
+  const [, navigate] = useLocation();
 
   const handleLocationSearch = () => {
     if (searchLocation.trim()) {
@@ -146,13 +148,10 @@ export default function HistoryPage() {
         </div>
 
         {/* Valuation History */}
-        <ValuationHistory 
-          limit={20} 
+        <ValuationHistory
+          limit={20}
           location={activeLocation}
-          onViewValuation={(id) => {
-            // TODO: Navigate to detailed valuation view
-            console.log('View valuation:', id);
-          }}
+          onViewValuation={(id) => navigate(`/valuation/${id}`)}
         />
       </div>
     </div>

--- a/client/src/pages/valuation-detail.tsx
+++ b/client/src/pages/valuation-detail.tsx
@@ -1,0 +1,99 @@
+import { AlertCircle, TrendingUp } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { ValuationResults } from "@/components/valuation-results";
+import { apiRequest } from "@/lib/queryClient";
+import { useQuery } from "@tanstack/react-query";
+import { useRoute, useLocation } from "wouter";
+import type { ValuationResult } from "@/lib/types";
+
+export default function ValuationDetailPage() {
+  const [, params] = useRoute<{ id: string }>("/valuation/:id");
+  const [, navigate] = useLocation();
+  const id = params?.id;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["/api/valuations", id],
+    queryFn: async () => {
+      const res = await apiRequest("GET", `/api/valuations/${id}`);
+      return res.json();
+    },
+    enabled: !!id,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <span className="text-gray-600">Loading...</span>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <AlertCircle className="h-8 w-8 text-red-500 mx-auto mb-4" />
+            <p className="text-gray-600">Unable to load valuation.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const result: ValuationResult = {
+    property: {
+      acreage: parseFloat(data.acreage),
+      location: data.location,
+      features: [
+        ...(data.irrigated ? ["Irrigated"] : []),
+        ...(data.tillable ? ["Tillable"] : []),
+        ...(data.cropType ? [data.cropType] : []),
+      ],
+    },
+    valuation: {
+      p10: data.p10,
+      p50: data.p50,
+      p90: data.p90,
+      totalValue: data.totalValue,
+      pricePerAcre: data.pricePerAcre,
+    },
+    analysis: {
+      narrative: data.narrative,
+      keyFactors: data.keyFactors,
+      confidence: parseFloat(data.confidence),
+    },
+    comparableSales: data.comparableSales,
+    sources: data.sources,
+    timestamp: data.createdAt,
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center space-x-3">
+              <div className="w-8 h-8 bg-gradient-to-br from-primary to-emerald-600 rounded-lg flex items-center justify-center">
+                <TrendingUp className="h-4 w-4 text-white" />
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">LandIQ</h1>
+                <p className="text-xs text-gray-500">Valuation Details</p>
+              </div>
+            </div>
+            <div className="flex items-center space-x-4">
+              <a href="/history" className="text-sm text-gray-600 hover:text-primary transition-colors">
+                History
+              </a>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <ValuationResults result={result} onNewValuation={() => navigate("/")} />
+      </div>
+    </div>
+  );
+}

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -360,7 +360,7 @@ Search for authentic, current market data from sources like USDA, university ext
                Math.round(sale.totalPrice / sale.pricePerAcre) : 50,
       features: Array.isArray(sale.features) ? sale.features : [],
       sourceUrl: sale.sourceUrl || undefined
-    })).filter(sale => sale.pricePerAcre > 0 && sale.totalPrice > 0 && sale.acreage > 0);
+    })).filter((sale: ComparableSale) => sale.pricePerAcre > 0 && sale.totalPrice > 0 && sale.acreage > 0);
 
     const sources: WebSource[] = parsedResponse.sources || webSearchSources;
 

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as true,
   };
 
   const vite = await createViteServer({


### PR DESCRIPTION
## Summary
- navigate to valuation detail page from history
- display individual valuation in new page
- add route for valuation details
- fix type errors for TypeScript check

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_685479c67a5c8324b4c339fc5604bd5d