### PR TITLE
Add agent chat endpoint and UI

### DIFF
--- a/client/src/components/agent-chat.tsx
+++ b/client/src/components/agent-chat.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { apiRequest } from "@/lib/queryClient";
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export function AgentChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [sessionId, setSessionId] = useState<string | undefined>(undefined);
+  const [input, setInput] = useState("");
+  const [isSending, setIsSending] = useState(false);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage: ChatMessage = { role: "user", content: input };
+    setMessages((m) => [...m, userMessage]);
+    setInput("");
+    setIsSending(true);
+    try {
+      const res = await apiRequest("POST", "/api/agent", {
+        sessionId,
+        message: userMessage.content,
+      });
+      const data = await res.json();
+      setSessionId(data.sessionId);
+      const reply: ChatMessage = { role: "assistant", content: data.message };
+      setMessages((m) => [...m, reply]);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold text-gray-900">Ask the Agent</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2 mb-4 max-h-64 overflow-y-auto text-sm">
+          {messages.map((m, idx) => (
+            <div key={idx} className={m.role === "user" ? "text-right" : "text-left"}>
+              <span className={m.role === "user" ? "bg-primary text-white px-2 py-1 rounded" : "bg-gray-100 px-2 py-1 rounded"}>{m.content}</span>
+            </div>
+          ))}
+        </div>
+        <div className="flex space-x-2">
+          <Input value={input} onChange={(e) => setInput(e.target.value)} placeholder="Type a message" />
+          <Button onClick={sendMessage} disabled={isSending}>Send</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/valuation-results.tsx
+++ b/client/src/components/valuation-results.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Clock, Brain, Search, Link, Download, Share, Plus, ExternalLink } from "lucide-react";
 import type { ValuationResult } from "@/lib/types";
+import { AgentChat } from "./agent-chat";
 
 interface ValuationResultsProps {
   result: ValuationResult;
@@ -237,6 +238,7 @@ export function ValuationResults({ result, onNewValuation }: ValuationResultsPro
           New Valuation
         </Button>
       </div>
+      <AgentChat />
     </div>
   );
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { propertyInputSchema, valuationResultSchema } from "../shared/schema";
 import { generateLandValuation } from "./services/openai";
+import { handleAgentMessage } from "./services/agent";
 import { storage } from "./storage";
 import { z } from "zod";
 
@@ -129,6 +130,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({
         message: "Failed to fetch valuation"
       });
+    }
+  });
+
+  // Conversational agent endpoint
+  app.post("/api/agent", async (req, res) => {
+    try {
+      const { sessionId, message } = req.body as { sessionId?: string; message: string };
+      if (!message) {
+        return res.status(400).json({ message: "message is required" });
+      }
+
+      const response = await handleAgentMessage({ sessionId, message });
+      res.json(response);
+    } catch (error) {
+      console.error("Agent error:", error);
+      res.status(500).json({ message: "Failed to process agent request" });
     }
   });
 

--- a/server/services/agent.ts
+++ b/server/services/agent.ts
@@ -1,0 +1,118 @@
+import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { generateLandValuation, ValuationData, PropertyData, openaiClient } from "./openai";
+
+export interface AgentMessageRequest {
+  sessionId?: string;
+  message: string;
+}
+
+export interface AgentMessageResponse {
+  sessionId: string;
+  message: string;
+}
+
+interface Session {
+  messages: ChatCompletionMessageParam[];
+}
+
+const sessions = new Map<string, Session>();
+
+// Simple valuation adjustment function
+export function adjustValuation(params: { valuation: ValuationData; factor: number }): ValuationData {
+  const { valuation, factor } = params;
+  return {
+    p10: Math.round(valuation.p10 * factor),
+    p50: Math.round(valuation.p50 * factor),
+    p90: Math.round(valuation.p90 * factor),
+    totalValue: Math.round(valuation.totalValue * factor),
+    pricePerAcre: Math.round(valuation.pricePerAcre * factor),
+    confidence: valuation.confidence,
+  };
+}
+
+export async function handleAgentMessage(request: AgentMessageRequest) : Promise<AgentMessageResponse> {
+  const { sessionId = crypto.randomUUID(), message } = request;
+
+  const session = sessions.get(sessionId) || {
+    messages: [
+      { role: "system", content: "You are a helpful land valuation assistant." },
+    ],
+  };
+
+  session.messages.push({ role: "user", content: message });
+
+  const tools: any = [
+    {
+      type: "function",
+      function: {
+        name: "generateLandValuation",
+        description: "Generate a land valuation for the given property",
+        parameters: {
+          type: "object",
+          properties: {
+            propertyDescription: { type: "string" },
+            acreage: { type: "number" },
+            location: { type: "string" },
+            irrigated: { type: "boolean" },
+            tillable: { type: "boolean" },
+            cropType: { type: "string" },
+          },
+          required: ["propertyDescription", "acreage", "location", "irrigated", "tillable"],
+        },
+      },
+    },
+    {
+      type: "function",
+      function: {
+        name: "adjustValuation",
+        description: "Adjust an existing valuation by a factor",
+        parameters: {
+          type: "object",
+          properties: {
+            valuation: { type: "object" },
+            factor: { type: "number" },
+          },
+          required: ["valuation", "factor"],
+        },
+      },
+    },
+  ];
+
+  const completion = await openaiClient.chat.completions.create({
+    model: "gpt-4o",
+    messages: session.messages,
+    tools,
+  });
+
+  const choice = completion.choices[0];
+  const assistantMessage = choice.message;
+
+  session.messages.push(assistantMessage as ChatCompletionMessageParam);
+
+  if (assistantMessage.tool_calls) {
+    for (const call of assistantMessage.tool_calls) {
+      const fnName = call.function.name;
+      const args = JSON.parse(call.function.arguments || "{}");
+      let result: any = {};
+      if (fnName === "generateLandValuation") {
+        result = await generateLandValuation(args as PropertyData);
+      } else if (fnName === "adjustValuation") {
+        result = adjustValuation(args as { valuation: ValuationData; factor: number });
+      }
+      session.messages.push({ role: "tool", content: JSON.stringify(result), tool_call_id: call.id } as any);
+    }
+
+    const followUp = await openaiClient.chat.completions.create({
+      model: "gpt-4o",
+      messages: session.messages,
+    });
+
+    const finalMessage = followUp.choices[0].message;
+    session.messages.push(finalMessage as ChatCompletionMessageParam);
+    sessions.set(sessionId, session);
+    return { sessionId, message: finalMessage.content || "" };
+  }
+
+  sessions.set(sessionId, session);
+  return { sessionId, message: assistantMessage.content || "" };
+}

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -9,7 +9,7 @@ if (!apiKey) {
   );
 }
 
-const openai = new OpenAI({ apiKey });
+export const openaiClient = new OpenAI({ apiKey });
 
 export interface PropertyData {
   propertyDescription: string;
@@ -120,7 +120,7 @@ export async function generateLandValuation(propertyData: PropertyData): Promise
     const region = locationParts.length > 1 ? locationParts[0] : propertyData.location;
 
     // Use OpenAI's Responses API with web search to get real-time farmland data
-    const response = await openai.responses.create({
+    const response = await openaiClient.responses.create({
       model: "gpt-4.1",
       tools: [
         {


### PR DESCRIPTION
## Summary
- expose `openaiClient` in OpenAI service
- create `agent.ts` service to manage chat sessions and function calls
- add `/api/agent` endpoint
- implement `<AgentChat>` component
- allow chatting below valuation results

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68547de2d2d08324b556e15003439d89